### PR TITLE
Support for Rails 3.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source "http://rubygems.org"
 # Example:
 gem "activesupport", ">= 3.0.7"
 gem "i18n"
-gem 'builder', '~> 2.0'
+gem 'builder', ">= 2.0.0", "< 3.1.0"
 
 # Add dependencies to develop your gem here.
 # Include everything needed to run rake, tests, features, etc.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,34 +1,41 @@
 GEM
   remote: http://rubygems.org/
   specs:
-    activesupport (3.0.8)
-    builder (2.1.2)
-    diff-lcs (1.1.2)
+    activesupport (3.2.3)
+      i18n (~> 0.6)
+      multi_json (~> 1.0)
+    builder (3.0.0)
+    diff-lcs (1.1.3)
     fakeweb (1.3.0)
     git (1.2.5)
     i18n (0.6.0)
-    jeweler (1.6.2)
+    jeweler (1.6.4)
       bundler (~> 1.0)
       git (>= 1.2.5)
       rake
-    rake (0.9.2)
-    rcov (0.9.9)
-    rspec (2.6.0)
-      rspec-core (~> 2.6.0)
-      rspec-expectations (~> 2.6.0)
-      rspec-mocks (~> 2.6.0)
-    rspec-core (2.6.4)
-    rspec-expectations (2.6.0)
-      diff-lcs (~> 1.1.2)
-    rspec-mocks (2.6.0)
-    shoulda (2.11.3)
+    multi_json (1.3.4)
+    rake (0.9.2.2)
+    rcov (1.0.0)
+    rspec (2.10.0)
+      rspec-core (~> 2.10.0)
+      rspec-expectations (~> 2.10.0)
+      rspec-mocks (~> 2.10.0)
+    rspec-core (2.10.0)
+    rspec-expectations (2.10.0)
+      diff-lcs (~> 1.1.3)
+    rspec-mocks (2.10.1)
+    shoulda (3.0.1)
+      shoulda-context (~> 1.0.0)
+      shoulda-matchers (~> 1.0.0)
+    shoulda-context (1.0.0)
+    shoulda-matchers (1.0.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   activesupport (>= 3.0.7)
-  builder (~> 2.0)
+  builder (>= 2.0.0, < 3.1.0)
   bundler (~> 1.0.0)
   fakeweb
   i18n

--- a/cielo.gemspec
+++ b/cielo.gemspec
@@ -46,7 +46,7 @@ Gem::Specification.new do |s|
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<activesupport>, [">= 3.0.7"])
       s.add_runtime_dependency(%q<i18n>, [">= 0"])
-      s.add_runtime_dependency(%q<builder>, ["~> 2.0"])
+      s.add_runtime_dependency(%q<builder>, [">= 2.0.0","< 3.1.0"])
       s.add_development_dependency(%q<shoulda>, [">= 0"])
       s.add_development_dependency(%q<bundler>, ["~> 1.0.0"])
       s.add_development_dependency(%q<jeweler>, ["~> 1.6.0"])
@@ -56,7 +56,7 @@ Gem::Specification.new do |s|
     else
       s.add_dependency(%q<activesupport>, [">= 3.0.7"])
       s.add_dependency(%q<i18n>, [">= 0"])
-      s.add_dependency(%q<builder>, ["~> 2.0"])
+      s.add_dependency(%q<builder>, [">= 2.0.0","< 3.1.0"])
       s.add_dependency(%q<shoulda>, [">= 0"])
       s.add_dependency(%q<bundler>, ["~> 1.0.0"])
       s.add_dependency(%q<jeweler>, ["~> 1.6.0"])
@@ -67,7 +67,7 @@ Gem::Specification.new do |s|
   else
     s.add_dependency(%q<activesupport>, [">= 3.0.7"])
     s.add_dependency(%q<i18n>, [">= 0"])
-    s.add_dependency(%q<builder>, ["~> 2.0"])
+    s.add_dependency(%q<builder>, [">= 2.0.0","< 3.1.0"])
     s.add_dependency(%q<shoulda>, [">= 0"])
     s.add_dependency(%q<bundler>, ["~> 1.0.0"])
     s.add_dependency(%q<jeweler>, ["~> 1.6.0"])


### PR DESCRIPTION
Builder version now can be between 2.0.0 (>=) and 3.1.0 (<)
Tested on ree 1.8.7
