### PR TITLE
Ruby 1.8.7 require net/https to create secure connections

### DIFF
--- a/lib/cielo.rb
+++ b/lib/cielo.rb
@@ -3,6 +3,7 @@ require 'active_support/core_ext/class/attribute_accessors'
 require 'active_support/core_ext/module/attribute_accessors'
 require 'active_support/core_ext/hash'
 require "net/http"
+require "net/https"
 require "rexml/document"
 require "builder"
 [:connection, :transaction].each { |lib| require "cielo/#{lib}" }


### PR DESCRIPTION
The gem was not working for me with ruby 1.8.7.

The error occurred on this line [1]

After require 'net/https' it started working.

I've tested with ruby 1.9.3 and it works too.

[1] https://github.com/crafters/cielo/blob/b58eabe637d1ff5f198978bb1932057b01d50635/lib/cielo/connection.rb#L8
