### PR TITLE
Let the user specify the numero_afiliacao and chave_acesso in the initialize method. 

### DIFF
--- a/lib/cielo/connection.rb
+++ b/lib/cielo/connection.rb
@@ -3,8 +3,13 @@
 module Cielo
   class Connection
     attr_reader :environment
-    def initialize
+    attr_reader :numero_afiliacao
+    attr_reader :chave_acesso
+
+    def initialize numero_afiliacao = Cielo.numero_afiliacao, chave_acesso = Cielo.chave_acesso
       @environment = eval(Cielo.environment.to_s.capitalize)
+      @numero_afiliacao = numero_afiliacao
+      @chave_acesso = chave_acesso
       port = 443
       @http = Net::HTTP.new(@environment::BASE_URL,port)
       @http.ssl_version = :SSLv3 if @http.respond_to? :ssl_version
@@ -12,10 +17,10 @@ module Cielo
       @http.open_timeout = 10*1000
       @http.read_timeout = 40*1000
     end
-    
+
     def request!(params={})
       str_params = ""
-      params.each do |key, value| 
+      params.each do |key, value|
         str_params+="&" unless str_params.empty?
         str_params+="#{key}=#{value}"
       end
@@ -28,8 +33,8 @@ module Cielo
       xml.tag!(group_name, :id => "#{Time.now.to_i}", :versao => "1.2.1") do
         block.call(xml) if target == :before
         xml.tag!("dados-ec") do
-          xml.numero Cielo.numero_afiliacao
-          xml.chave Cielo.chave_acesso
+          xml.numero @numero_afiliacao #Cielo.numero_afiliacao
+          xml.chave @chave_acesso #Cielo.chave_acesso
         end
         block.call(xml) if target == :after
       end
@@ -51,7 +56,7 @@ module Cielo
         {:erro => { :codigo => "000", :mensagem => "Impossível contactar o servidor"}}
       end
     end
-    
+
     def parse_elements(elements)
       map={}
       elements.each do |element|

--- a/lib/cielo/transaction.rb
+++ b/lib/cielo/transaction.rb
@@ -1,8 +1,14 @@
 #encoding: utf-8
 module Cielo
   class Transaction
-    def initialize
-      @connection = Cielo::Connection.new
+
+    attr_reader :numero_afiliacao
+    attr_reader :chave_acesso
+
+    def initialize numero_afiliacao = Cielo.numero_afiliacao, chave_acesso = Cielo.chave_acesso
+      @numero_afiliacao = numero_afiliacao
+      @chave_acesso = chave_acesso
+      @connection = Cielo::Connection.new @numero_afiliacao, @chave_acesso
     end
 
     def create!(parameters = {}, buy_page = :cielo)
@@ -18,7 +24,7 @@ module Cielo
       message = @connection.xml_builder('requisicao-transacao') do |xml|
         xml.tag!("dados-portador") do
           if parameters[:token].present?
-            xml.tag!('token', parameters[:token])  
+            xml.tag!('token', parameters[:token])
           else
             xml.tag!('numero', parameters[:cartao_numero])
             xml.tag!('validade', parameters[:cartao_validade])
@@ -72,7 +78,7 @@ module Cielo
       message = @connection.xml_builder("requisicao-cancelamento", :before) do |xml|
         xml.tid "#{cielo_tid}"
       end
-      @connection.make_request! message      
+      @connection.make_request! message
     end
 
     private
@@ -98,7 +104,7 @@ module Cielo
 
       if buy_page == :buy_page_store
         if parameters[:token].present?
-          to_analyze.concat([:token])  
+          to_analyze.concat([:token])
         else
           to_analyze.concat([:cartao_numero, :cartao_validade, :cartao_seguranca, :cartao_portador])
         end
@@ -122,6 +128,6 @@ module Cielo
       parameters
     end
 
-    
+
   end
 end

--- a/spec/cielo/connection_spec.rb
+++ b/spec/cielo/connection_spec.rb
@@ -5,14 +5,16 @@ describe Cielo::Connection do
     FakeWeb.allow_net_connect = true
 
     @connection = Cielo::Connection.new
+    @connection2 = Cielo::Connection.new "1001734898", "e84827130b9837473681c2787007da5914d6359947015a5cdb2b8843db0fa832"
   end
 
   after do
     FakeWeb.allow_net_connect = false
   end
-  
+
   it "should estabilish connection when was created" do
     @connection.environment.should_not be_nil
+    @connection2.environment.should_not be_nil
   end
 
   describe "making a request" do
@@ -23,4 +25,14 @@ describe Cielo::Connection do
       response.should be_kind_of Net::HTTPSuccess
     end
   end
+
+  describe "passing an access key and a client number" do
+    it "should make a request whithout any problem" do
+      response = @connection2.request! :data => "Anything"
+
+      response.body.should_not be_nil
+      response.should be_kind_of Net::HTTPSuccess
+    end
+  end
+
 end

--- a/spec/cielo/transaction_spec.rb
+++ b/spec/cielo/transaction_spec.rb
@@ -12,8 +12,8 @@ describe Cielo::Transaction do
     @token = Cielo::Token.new
   end
 
-  describe "create a buy page store transaction with token" do 
-    before do 
+  describe "create a buy page store transaction with token" do
+    before do
       Cielo.stub(:numero_afiliacao).and_return('1006993069')
       Cielo.stub(:chave_acesso).and_return('25fbb99741c739dd84d7b06ec78c9bac718838630f30b112d033ce2e621b34f3')
 
@@ -38,7 +38,7 @@ describe Cielo::Transaction do
   end
 
   describe "create a recurring transaction with token" do
-    before do 
+    before do
       Cielo.stub(:numero_afiliacao).and_return('1006993069')
       Cielo.stub(:chave_acesso).and_return('25fbb99741c739dd84d7b06ec78c9bac718838630f30b112d033ce2e621b34f3')
 
@@ -64,7 +64,7 @@ describe Cielo::Transaction do
   end
 
   # Error on system when uses gerar-token => true (Verify with Cielo)
-  describe "create a buy page store transaction with token generation" do 
+  describe "create a buy page store transaction with token generation" do
     before do
       FakeWeb.register_uri(:any, "https://qasecommerce.cielo.com.br/servicos/ecommwsec.do",
         :body => "<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?><transacao versao=\"1.2.1\" id=\"1390315327\" xmlns=\"http://ecommerce.cbmp.com.br\"><tid>10069930690DCC341001</tid><pan>52WC7RsmcNuEUSjrYWAEhCOjoLMnMCm4KMTQBqN7PdM=</pan><dados-pedido><numero>1</numero><valor>100</valor><moeda>986</moeda><data-hora>2014-01-21T12:42:08.865-02:00</data-hora><idioma>PT</idioma><taxa-embarque>0</taxa-embarque></dados-pedido><forma-pagamento><bandeira>visa</bandeira><produto>1</produto><parcelas>1</parcelas></forma-pagamento><status>6</status><autenticacao><codigo>6</codigo><mensagem>Transacao sem autenticacao</mensagem><data-hora>2014-01-21T12:42:08.872-02:00</data-hora><valor>100</valor><eci>7</eci></autenticacao><autorizacao><codigo>6</codigo><mensagem>Transa??o autorizada</mensagem><data-hora>2014-01-21T12:42:08.885-02:00</data-hora><valor>100</valor><lr>00</lr><arp>123456</arp><nsu>904244</nsu></autorizacao><captura><codigo>6</codigo><mensagem>Transacao capturada com sucesso</mensagem><data-hora>2014-01-21T12:42:08.912-02:00</data-hora><valor>100</valor></captura><token><dados-token><codigo-token>2ta/YqYaeyolf2NHkBWO8grPqZE44j3PvRAQxVQQGgE=</codigo-token><status>1</status><numero-cartao-truncado>401288******1881</numero-cartao-truncado></dados-token></token></transacao>", :content_type => "application/xml")
@@ -209,6 +209,17 @@ describe Cielo::Transaction do
 
     it "must use the production environment" do
       Cielo.numero_afiliacao.should be_eql "1001734891"
+    end
+
+    it "must use the production client number" do
+      @connection = Cielo::Connection.new
+      @connection.numero_afiliacao.should be_eql "1001734891"
+    end
+
+    it "must use the configuration informed" do
+      @connection2 = Cielo::Connection.new "0100100100", "e84827130b9837473681c2787007da5914d6359947015a5cdb2b8843db0fa800"
+      @connection2.numero_afiliacao.should be_eql "0100100100"
+      @connection2.chave_acesso.should be_eql "e84827130b9837473681c2787007da5914d6359947015a5cdb2b8843db0fa800"
     end
 
   end


### PR DESCRIPTION
Hi,

I have a lot of numero_afiliacao and only one store (like a marketplace). I have to create a transaction with a different configuration each time. I changed the code to let me specify a numero_afiliacao and chave_acesso in transaction's initialize method but it is not mandatory. If this data is not informed it will work as expected before. I created a few tests and ran it. It seems to be working fine.
