### PR TITLE
Allow partial cancellations and no CVV transactions

### DIFF
--- a/lib/cielo/connection.rb
+++ b/lib/cielo/connection.rb
@@ -7,7 +7,7 @@ module Cielo
     attr_reader :chave_acesso
     attr_reader :versao
 
-    def initialize numero_afiliacao = Cielo.numero_afiliacao, chave_acesso = Cielo.chave_acesso, versao = '1.1.1'
+    def initialize numero_afiliacao = Cielo.numero_afiliacao, chave_acesso = Cielo.chave_acesso, versao = '1.2.1'
       @environment = eval(Cielo.environment.to_s.capitalize)
       @numero_afiliacao = numero_afiliacao
       @chave_acesso = chave_acesso

--- a/lib/cielo/connection.rb
+++ b/lib/cielo/connection.rb
@@ -5,11 +5,13 @@ module Cielo
     attr_reader :environment
     attr_reader :numero_afiliacao
     attr_reader :chave_acesso
+    attr_reader :versao
 
-    def initialize numero_afiliacao = Cielo.numero_afiliacao, chave_acesso = Cielo.chave_acesso
+    def initialize numero_afiliacao = Cielo.numero_afiliacao, chave_acesso = Cielo.chave_acesso, versao = '1.1.1'
       @environment = eval(Cielo.environment.to_s.capitalize)
       @numero_afiliacao = numero_afiliacao
       @chave_acesso = chave_acesso
+      @versao = versao
       port = 443
       @http = Net::HTTP.new(@environment::BASE_URL,port)
       @http.ssl_version = :TLSv1 if @http.respond_to? :ssl_version
@@ -30,7 +32,7 @@ module Cielo
     def xml_builder(group_name, target=:after, &block)
       xml = Builder::XmlMarkup.new
       xml.instruct! :xml, :version=>"1.0", :encoding=>"ISO-8859-1"
-      xml.tag!(group_name, :id => "#{Time.now.to_i}", :versao => "1.1.1") do
+      xml.tag!(group_name, :id => "#{Time.now.to_i}", :versao => @versao) do
         block.call(xml) if target == :before
         xml.tag!("dados-ec") do
           xml.numero @numero_afiliacao #Cielo.numero_afiliacao

--- a/lib/cielo/connection.rb
+++ b/lib/cielo/connection.rb
@@ -30,7 +30,7 @@ module Cielo
     def xml_builder(group_name, target=:after, &block)
       xml = Builder::XmlMarkup.new
       xml.instruct! :xml, :version=>"1.0", :encoding=>"ISO-8859-1"
-      xml.tag!(group_name, :id => "#{Time.now.to_i}", :versao => "1.2.1") do
+      xml.tag!(group_name, :id => "#{Time.now.to_i}", :versao => "1.1.1") do
         block.call(xml) if target == :before
         xml.tag!("dados-ec") do
           xml.numero @numero_afiliacao #Cielo.numero_afiliacao

--- a/lib/cielo/connection.rb
+++ b/lib/cielo/connection.rb
@@ -29,16 +29,16 @@ module Cielo
       @http.request_post(self.environment::WS_PATH, str_params)
     end
 
-    def xml_builder(group_name, target=:after, &block)
+    def xml_builder(group_name, &block)
       xml = Builder::XmlMarkup.new
       xml.instruct! :xml, :version=>"1.0", :encoding=>"ISO-8859-1"
       xml.tag!(group_name, :id => "#{Time.now.to_i}", :versao => @versao) do
-        block.call(xml) if target == :before
+        block.call(xml, :before)
         xml.tag!("dados-ec") do
           xml.numero @numero_afiliacao #Cielo.numero_afiliacao
           xml.chave @chave_acesso #Cielo.chave_acesso
         end
-        block.call(xml) if target == :after
+        block.call(xml, :after)
       end
       xml
     end

--- a/lib/cielo/token.rb
+++ b/lib/cielo/token.rb
@@ -6,11 +6,13 @@ module Cielo
     end
 
     def create!(parameters = {}, buy_page = :cielo)
-      message = @connection.xml_builder('requisicao-token') do |xml|
-        xml.tag!("dados-portador") do
-          xml.tag!('numero', parameters[:cartao_numero])
-          xml.tag!('validade', parameters[:cartao_validade])
-          xml.tag!('nome-portador', parameters[:cartao_portador])
+      message = @connection.xml_builder('requisicao-token') do |xml, target|
+        if target == :after
+          xml.tag!("dados-portador") do
+            xml.tag!('numero', parameters[:cartao_numero])
+            xml.tag!('validade', parameters[:cartao_validade])
+            xml.tag!('nome-portador', parameters[:cartao_portador])
+          end
         end
       end
 

--- a/lib/cielo/transaction.rb
+++ b/lib/cielo/transaction.rb
@@ -6,7 +6,7 @@ module Cielo
     attr_reader :chave_acesso
     attr_reader :versao
 
-    def initialize numero_afiliacao = Cielo.numero_afiliacao, chave_acesso = Cielo.chave_acesso, versao = '1.1.1'
+    def initialize numero_afiliacao = Cielo.numero_afiliacao, chave_acesso = Cielo.chave_acesso, versao = '1.2.1'
       @numero_afiliacao = numero_afiliacao
       @chave_acesso = chave_acesso
       @versao = versao
@@ -109,7 +109,8 @@ module Cielo
         if parameters[:token].present?
           to_analyze.concat([:token])
         else
-          to_analyze.concat([:cartao_numero, :cartao_validade, :cartao_portador]) # :cartao_seguranca
+          to_analyze.concat([:cartao_numero, :cartao_validade, :cartao_portador])
+          to_analyze.concat([:cartao_seguranca]) unless ['1.0.0', '1.1.0', '1.1.1'].include?(@versao)
         end
       end
 

--- a/lib/cielo/transaction.rb
+++ b/lib/cielo/transaction.rb
@@ -106,7 +106,7 @@ module Cielo
         if parameters[:token].present?
           to_analyze.concat([:token])
         else
-          to_analyze.concat([:cartao_numero, :cartao_validade, :cartao_seguranca, :cartao_portador])
+          to_analyze.concat([:cartao_numero, :cartao_validade, :cartao_portador]) # :cartao_seguranca
         end
       end
 

--- a/lib/cielo/transaction.rb
+++ b/lib/cielo/transaction.rb
@@ -4,11 +4,13 @@ module Cielo
 
     attr_reader :numero_afiliacao
     attr_reader :chave_acesso
+    attr_reader :versao
 
-    def initialize numero_afiliacao = Cielo.numero_afiliacao, chave_acesso = Cielo.chave_acesso
+    def initialize numero_afiliacao = Cielo.numero_afiliacao, chave_acesso = Cielo.chave_acesso, versao = '1.1.1'
       @numero_afiliacao = numero_afiliacao
       @chave_acesso = chave_acesso
-      @connection = Cielo::Connection.new @numero_afiliacao, @chave_acesso
+      @versao = versao
+      @connection = Cielo::Connection.new @numero_afiliacao, @chave_acesso, @versao
     end
 
     def create!(parameters = {}, buy_page = :cielo)
@@ -73,10 +75,11 @@ module Cielo
       @connection.make_request! message
     end
 
-    def cancel!(cielo_tid)
+    def cancel!(cielo_tid, valor=nil)
       return nil unless cielo_tid
       message = @connection.xml_builder("requisicao-cancelamento", :before) do |xml|
         xml.tid "#{cielo_tid}"
+        xml.valor "#{valor}" if valor.to_d > 0
       end
       @connection.make_request! message
     end


### PR DESCRIPTION
### Allow sending no CVV: ###
Transactions without CVV are not allowed starting at version 1.2.0, so we must use an earlier version. In order to use an earlier version of the API, one could do:

`transaction = Cielo::Transaction.new(Cielo.numero_afiliacao, Cielo.chave_acesso, versao = '1.1.1')`

### Allow partial cancelations ###
In order to do partial cancelations one could do:

`transaction = Cielo::Transaction.new`
`tid = 'XXXX'`
`value_in_cents = '100' # for R$ 1,00`
`response = transaction.cancel!(tid, value_in_cents)`

Since the `valor` field comes after the ec, and the tid comes before, I had to change the topology of the :after and :before to send it along to the block, and add an if inside the block. The block now gets called twice for each method, which has somewhat of a performance penalty but I believe it's nothing big.